### PR TITLE
Add instructions to link Postgres CLI tools

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -135,6 +135,10 @@ begin
       end
       
       puts "Installed Postgres app, this app hosts your database while it is being ran."
+
+      puts "You will need to add the following line to your ~/.bash_profile or ~/.bashrc file:"
+      puts "\"export PATH=$PATH:/Applications/Postgres.app/Contents/Versions/9.4/bin\""
+
     end
     
   end


### PR DESCRIPTION
The Strata tooling all assumes a `psql` command exists in the $PATH, but a fresh install of Postgres.app won't automatically have its CLI tools exposed that way (see http://postgresapp.com/documentation/cli-tools.html). This just adds some output to the `rake install_system_deps` command instructing users to add Postgres.app's path to their PATH.