### PR TITLE
Add index to LogMessage.pod_version_id

### DIFF
--- a/migrations/trunk/016_add_log_message_index.rb
+++ b/migrations/trunk/016_add_log_message_index.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :log_messages do
+      add_index [:pod_version_id], :unique => false
+    end
+  end
+end


### PR DESCRIPTION
Using `heroku pg:outliers --app=cocoapods-trunk-service` (via [heroku-pg-extras](https://github.com/heroku/heroku-pg-extras)) I noticed a **significant** amount of time querying for log messages compared to any other query:



```
 total_exec_time | prop_exec_time | ncalls |  sync_io_time   | query
 00:13:56.736557 | 93.8%          | 246    | 00:00:46.027763 | SELECT * FROM "log_messages" WHERE ("log_messages"."pod_version_id" = 639380) ORDER BY "created_at" ASC
 00:00:13.357977 | 1.5%           | 9      | 00:00:00        | SELECT "pods"."id", "pods"."name", "github_pod_metrics"."id" AS "github_pod_id", "github_pod_metrics"."pod_id" AS "github_pod_pod_id", "github_pod_metrics"."subscribers" AS "github_pod_subscribers", "github_pod_metrics"."stargazers" AS "github_pod_stargazers", "github_pod_metrics"."forks" AS "github_pod_forks", "github_pod_metrics"."contributors" AS "github_pod_contributors", "github_pod_metrics"."open_issues" AS "github_pod_open_issues", "github_pod_metrics"."open_pull_requests" AS "github_pod_open_pull_requests", "github_pod_metrics"."not_found" AS "github_pod_not_found", "github_pod_metrics"."created_at" AS "github_pod_created_at", "github_pod_metrics"."updated_at" AS "github_pod_updated_at", "github_pod_metrics"."language" AS "github_pod_language", "github_pod_metrics"."closed_issues" AS "github_pod_closed_issues", "github_pod_metrics"."closed_pull_requests" AS "github_pod_closed_pull_requests" FROM "pods" LEFT JOIN "github_pod_metrics" ON ("github_pod_metrics"."pod_id" = "pods"."id") WHERE ((github_pod_metrics.updated_at <= $1 OR github_pod_metrics.updated_at IS NULL) AND (github_pod_metrics.not_found < $2)) ORDER BY RANDOM() LIMIT $3
...
```

I believe this query is trigged from here https://github.com/CocoaPods/trunk.cocoapods.org/blob/b54aa7029b0612f09409ed11e7c4a7b463688c18/app/controllers/api/pods_controller.rb#L60

Using `heroku pg:index-usage --app=cocoapods-trunk-service` you can see how frequently a table hits an index. The LogMessage tabble is at 0%

```
heroku pg:index-usage --app=cocoapods-trunk-service                                                                                                                                                                                                           ‹ruby-3.1.1›
        relname        | percent_of_times_index_used | rows_in_table 
-----------------------+-----------------------------+---------------
 sessions              | 94                          |         37859
 log_messages          | 0                           |          8683
 commits               | 99                          |          4171
 pod_versions          | 99                          |          3676
 owners_pods           | 99                          |           365
 pods                  | 96                          |           289
 github_pod_metrics    | 0                           |           289
 owners                | 99                          |           212
 disputes              | 4                           |             3
 schema_info_cocoadocs |                             |             0
 schema_info_stats     |                             |             0
 schema_info_metrics   |                             |             0
 stats_metrics         | Insufficient data           |             0
 schema_info           |                             |             0
 cocoadocs_pod_metrics | 0                           |             0
 total_stats           | 99                          |             0
(16 rows)
```

(Note: the `rows_in_table` column above is obviously wrong, not sure why)
